### PR TITLE
feat: API 훅 및 Query Key 추가

### DIFF
--- a/src/hooks/queries/musical/musical.queryKey.ts
+++ b/src/hooks/queries/musical/musical.queryKey.ts
@@ -1,0 +1,7 @@
+import type { GetMusicalListParams } from './useGetMusicalList';
+
+export const musicalQueryKey = {
+  all: () => ['musical'],
+  list: (params: GetMusicalListParams) => [...musicalQueryKey.all(), 'list', params],
+  detail: (id: string) => [...musicalQueryKey.all(), 'detail', id],
+};

--- a/src/hooks/queries/musical/useDeleteMusical.ts
+++ b/src/hooks/queries/musical/useDeleteMusical.ts
@@ -1,0 +1,14 @@
+import { instance } from '@/lib/axios';
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+export const deleteMusical = async (musicalId: string) => {
+  const response = await instance.delete(`/musical/${musicalId}`);
+  return response.data;
+};
+
+export const useDeleteMusical = (options?: UseMutationOptions<ApiSuccessResponse<undefined>, ApiFailureResponse, string>) => {
+  return useMutation({
+    mutationFn: (musicalId: string) => deleteMusical(musicalId),
+    ...options,
+  });
+};

--- a/src/hooks/queries/musical/useGetMusicalDetail.ts
+++ b/src/hooks/queries/musical/useGetMusicalDetail.ts
@@ -1,0 +1,33 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { musicalQueryKey } from './musical.queryKey';
+import { instance } from '@/lib/axios';
+
+export interface MusicalNumber {
+  title: string;
+  videoUrl: string;
+  actors: string[];
+  act: number;
+  order: number;
+}
+
+export interface GetMusicalDetailResponseData {
+  title: string;
+  synopsis: string;
+  imageUrl: string;
+  numbers: MusicalNumber[];
+}
+
+export type GetMusicalDetailResponse = ApiSuccessResponse<GetMusicalDetailResponseData>;
+
+export const getMusicalDetail = async (musicalId: string) => {
+  const response = await instance.get(`/musicals/${musicalId}`);
+  return response.data;
+};
+
+export const useGetMusicalDetail = (musicalId: string, options?: UseQueryOptions<GetMusicalDetailResponse>) => {
+  return useQuery({
+    queryKey: musicalQueryKey.detail(musicalId),
+    queryFn: () => getMusicalDetail(musicalId),
+    ...options,
+  });
+};

--- a/src/hooks/queries/musical/useGetMusicalList.ts
+++ b/src/hooks/queries/musical/useGetMusicalList.ts
@@ -1,0 +1,29 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { musicalQueryKey } from './musical.queryKey';
+import { instance } from '@/lib/axios';
+import type { GetPosterListResponseData } from '../poster/useGetPosterList';
+
+export interface GetMusicalListParams {
+  initialRange?: string;
+}
+
+export interface GetMusicalListResponseData {
+  id: number;
+  title: string;
+  poster: GetPosterListResponseData[];
+}
+
+export type GetMusicalListResponse = ApiSuccessResponse<GetMusicalListResponseData[]>;
+
+export const getMusicalList = async (params: GetMusicalListParams) => {
+  const response = await instance.get('/musicals/filter', { params });
+  return response.data;
+};
+
+export const useGetMusicalList = (params: GetMusicalListParams, options?: Partial<UseQueryOptions<GetMusicalListResponse>>) => {
+  return useQuery({
+    queryKey: musicalQueryKey.list(params),
+    queryFn: () => getMusicalList(params),
+    ...options,
+  });
+};

--- a/src/hooks/queries/musical/usePostMusicalList.ts
+++ b/src/hooks/queries/musical/usePostMusicalList.ts
@@ -1,0 +1,31 @@
+import { instance } from '@/lib/axios';
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+export interface PostMusicalListRequestBody {
+  poster: string;
+  title: string;
+  info: string;
+  acts: {
+    title: number;
+    numbers: {
+      order: number;
+      youtubeLink: string;
+      title: string;
+      actors: { name: string }[];
+    }[];
+  }[];
+}
+
+export async function postMusicalList(body: PostMusicalListRequestBody) {
+  const response = await instance.post('/musicals', body);
+  return response.data;
+}
+
+export function usePostMusicalList(
+  options?: Partial<UseMutationOptions<ApiSuccessResponse<undefined>, ApiFailureResponse, PostMusicalListRequestBody>>
+) {
+  return useMutation({
+    mutationFn: (body: PostMusicalListRequestBody) => postMusicalList(body),
+    ...options,
+  });
+}

--- a/src/hooks/queries/musical/usePutMusical.ts
+++ b/src/hooks/queries/musical/usePutMusical.ts
@@ -1,0 +1,22 @@
+import { instance } from '@/lib/axios';
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { PostMusicalListRequestBody } from './usePostMusicalList';
+
+export type PutMusicalRequestBody = PostMusicalListRequestBody;
+
+interface PutMusicalRequestParams {
+  musicalId: string;
+  body: PutMusicalRequestBody;
+}
+
+export const putMusical = async (musicalId: string, body: PutMusicalRequestBody) => {
+  const response = await instance.put(`/musical/${musicalId}`, body);
+  return response.data;
+};
+
+export const usePutMusical = (options?: UseMutationOptions<ApiSuccessResponse<undefined>, ApiFailureResponse, PutMusicalRequestParams>) => {
+  return useMutation({
+    mutationFn: ({ musicalId, body }: PutMusicalRequestParams) => putMusical(musicalId, body),
+    ...options,
+  });
+};

--- a/src/hooks/queries/poster/poster.constants.ts
+++ b/src/hooks/queries/poster/poster.constants.ts
@@ -1,0 +1,6 @@
+export const POSTER_KEYWORD = {
+  RANDOM: 'random',
+  VIEWS: 'views',
+};
+
+export type PosterKeyword = (typeof POSTER_KEYWORD)[keyof typeof POSTER_KEYWORD];

--- a/src/hooks/queries/poster/poster.queryKey.ts
+++ b/src/hooks/queries/poster/poster.queryKey.ts
@@ -1,0 +1,7 @@
+import type { GetPosterListParams } from './useGetPosterList';
+
+export const posterQueryKey = {
+  all: () => ['poster'],
+  list: (params: GetPosterListParams) => [...posterQueryKey.all(), 'list', params],
+  detail: (id: string) => [...posterQueryKey.all(), 'detail', id],
+};

--- a/src/hooks/queries/poster/useGetPosterDetail.ts
+++ b/src/hooks/queries/poster/useGetPosterDetail.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { posterQueryKey } from './poster.queryKey';
+import { instance } from '@/lib/axios';
+
+export const getPosterDetail = async (id: string) => {
+  const response = await instance.get(`/posters/${id}`);
+  return response.data;
+};
+
+export const useGetPosterDetail = (id: string) => {
+  return useQuery({
+    queryKey: posterQueryKey.detail(id),
+    queryFn: () => getPosterDetail(id),
+    enabled: !!id,
+  });
+};

--- a/src/hooks/queries/poster/useGetPosterList.ts
+++ b/src/hooks/queries/poster/useGetPosterList.ts
@@ -1,0 +1,36 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { posterQueryKey } from './poster.queryKey';
+import { instance } from '@/lib/axios';
+
+export const POSTER_SEARCH_KEYWORD = {
+  RANDOM: 'random',
+  VIEWS: 'views',
+} as const;
+
+export interface GetPosterListParams {
+  mode?: (typeof POSTER_SEARCH_KEYWORD)[keyof typeof POSTER_SEARCH_KEYWORD];
+  limit?: number;
+  initialRange?: string;
+  musicalId?: number;
+}
+
+export interface GetPosterListResponseData {
+  musicalId: number;
+  title: string;
+  imageUrl: string;
+}
+
+export type GetPosterListResponse = ApiSuccessResponse<GetPosterListResponseData[]>;
+
+export const getPosterList = async (params: GetPosterListParams) => {
+  const response = await instance.get('/posters', { params });
+  return response.data;
+};
+
+export const useGetPosterList = (params: GetPosterListParams, options?: Partial<UseQueryOptions<GetPosterListResponse>>) => {
+  return useQuery({
+    queryKey: posterQueryKey.list(params),
+    queryFn: () => getPosterList(params),
+    ...options,
+  });
+};

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,0 +1,3 @@
+import axios from 'axios';
+
+export const instance = axios.create({ baseURL: '/api' });

--- a/src/type/api.d.ts
+++ b/src/type/api.d.ts
@@ -1,0 +1,14 @@
+type ApiResponse<T> = ApiSuccessResponse<T> | ApiFailureResponse;
+
+interface ApiSuccessResponse<T> {
+  success: true;
+  data: T;
+}
+
+interface ApiFailureResponse {
+  success: false;
+  error: {
+    code: string;
+    message: string;
+  };
+}


### PR DESCRIPTION
- 기존 API 호출 방식을 REST API 기반으로 전환
- 전환된 API에 맞춰 코드 전반 리팩토링 진행
- 스쿼시 머지 형태로 깃 히스토리 관리 및 변경